### PR TITLE
Improve shell scripts - add deploy_csv script

### DIFF
--- a/deploy_csv.sh
+++ b/deploy_csv.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#Script created to copy csv config file to jmeter slave pods
+#It requires that you supply the path to the csv file and destination path in the jmeter pods
+
+namespace="$1"
+
+[ -n "$namespace" ] || read -p 'Enter the Jmeter Namespace: ' namespace
+
+kubectl get namespace | grep $namespace >> /dev/null
+
+if [ $? != 0 ];
+then
+    echo "Namespace does not exist in the kubernetes cluster"
+    echo ""
+    echo "Below is the list of namespaces in the kubernetes cluster"
+
+    kubectl get namespaces
+    echo ""
+    echo "Please check and try again"
+    exit
+fi
+
+csv="$2"
+[ -n "$csv" ] || read -p 'Enter path to the csv file:' csv
+
+if [ ! -f "$csv" ];
+then
+    echo "csv file was not found in PATH"
+    echo "Kindly check and input the correct file path"
+    exit
+fi
+
+csv_name="$(basename "$csv")"
+
+path="$3"
+[ -n "$path" ] || read -p 'Enter destination path:' path
+
+
+
+#Get Master pod details
+
+kubectl -n $namespace get po | grep jmeter-slave | grep Running | awk '{print $1}' | while read -r slave_pod ; do
+    echo "Deploying $csv_name to:  $slave_pod"
+    kubectl -n $namespace cp "$csv" "$slave_pod:$path/$csv_name"
+done
+
+
+

--- a/start_test.sh
+++ b/start_test.sh
@@ -21,8 +21,8 @@ then
     exit
 fi
 
-jmx="$1"
-[ -n "$jmx" ] || read -p 'Enter path to the jmx file ' jmx
+jmx="$2"
+[ -n "$jmx" ] || read -p 'Enter path to the jmx file:' jmx
 
 if [ ! -f "$jmx" ];
 then
@@ -32,6 +32,7 @@ then
 fi
 
 test_name="$(basename "$jmx")"
+
 
 #Get Master pod details
 


### PR DESCRIPTION
Refactor start_test.sh and adding deploy_csv.sh in order to support csv config file.


The `deploy_scv.sh` script is an interactive shell script, allowing to specify namespace, local csv file path and destination path.
It deploy the csv file to the specified path in all jmaster-salves pods.