### PR TITLE
Added containerPort for jmeter slave to expose prometheus metrics

### DIFF
--- a/roles/jmeter/tasks/main.yml
+++ b/roles/jmeter/tasks/main.yml
@@ -83,6 +83,7 @@
               ports:
               - containerPort: 1099
               - containerPort: 50000          
+              - containerPort: 9270
 
 - name: Create Jmeter Slave Service    
   k8s:


### PR DESCRIPTION
Jmeter Prometheus plugin (https://github.com/johrstrom/jmeter-prometheus-plugin) exposes metrics in port 9270. This change will expose the the containerPort 9270 on the jmeter slaves, so that Prometheus metrics can be collected from the jmeter slaves during test execution.